### PR TITLE
Revert age uint32 -> uint256

### DIFF
--- a/src/mosm.sol
+++ b/src/mosm.sol
@@ -65,7 +65,7 @@ contract Mosm is LibNote {
     }
 
     uint128        val;
-    uint32  public age;
+    uint256  public age;
     bytes32 public constant wat = "ethusd"; // You want to change this every deploy
     uint256 public bar = 1;
 
@@ -96,7 +96,7 @@ contract Mosm is LibNote {
         return (val, val > 0);
     }
 
-    function recover(uint256 val_, uint32 age_, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
+    function recover(uint256 val_, uint256 age_, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
         return ecrecover(
             keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", keccak256(abi.encodePacked(val_, age_, wat)))),
             v, r, s
@@ -105,14 +105,14 @@ contract Mosm is LibNote {
 
     // Median
     function poke(
-        uint256[] calldata val_, uint32[] calldata age_,
+        uint256[] calldata val_, uint256[] calldata age_,
         uint8[] calldata v, bytes32[] calldata r, bytes32[] calldata s) external
     {
         require(val_.length == bar, "Median/bar-too-low");
 
         uint256 bloom = 0;
         uint256 last = 0;
-        uint32 snooze = age;
+        uint256 snooze = age;
 
         for (uint i = 0; i < val_.length; i++) {
             // Validate the values were signed by an authorized oracle
@@ -131,7 +131,7 @@ contract Mosm is LibNote {
         }
 
         val = uint128(val_[val_.length >> 1]);
-        age = uint32(block.timestamp);
+        age = block.timestamp;
 
         emit LogMedianPrice(val, age);
     }
@@ -305,15 +305,13 @@ contract Mosm is LibNote {
 }
 
 //// Create new deploy: Uncomment the below and modify contract name + wat ////
-/*
 contract MosmETHUSD is Mosm {
     bytes32 public constant wat = "ETHUSD";
 
-    function recover(uint256 val_, uint32 age_, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
+    function recover(uint256 val_, uint256 age_, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
         return ecrecover(
             keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", keccak256(abi.encodePacked(val_, age_, wat)))),
             v, r, s
         );
     }
 }
-*/

--- a/src/mosm.t.sol
+++ b/src/mosm.t.sol
@@ -26,44 +26,168 @@ contract Unauthorized {
     }
 }
 
+contract TestMosmETHUSD is Mosm {
+    bytes32 public constant wat = "ETHUSD";
+
+    function recover(uint256 val_, uint256 age_, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
+        return ecrecover(
+            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", keccak256(abi.encodePacked(val_, age_, wat)))),
+            v, r, s
+        );
+    }
+}
+
 contract MosmTest is DSTest {
-    Mosm mosm;
+    TestMosmETHUSD mosm;
     Unauthorized u;
     Hevm hevm;
-    uint256 testprice = 108000000000000000000;
+    uint256 testprice = 258000000000000000000;
 
     function setUp() public {
-        mosm = new Mosm();
+        mosm = new TestMosmETHUSD();
         u = new Unauthorized(mosm);
         hevm = Hevm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
     }
 
     function medianInit() public returns
-        (address[] memory, uint256[] memory, uint32[] memory, bytes32[] memory, bytes32[] memory, uint8[] memory) {
+        (address[] memory, uint256[] memory, uint256[] memory, bytes32[] memory, bytes32[] memory, uint8[] memory) {
 
         address[] memory orcl = new address[](15);
         uint256[] memory price = new uint256[](15);
-        uint32[] memory ts = new uint32[](15);
+        uint256[] memory ts = new uint256[](15);
         bytes32[] memory r = new bytes32[](15);
         bytes32[] memory s = new bytes32[](15);
         uint8[] memory v = new uint8[](15);
 
         // ----------- accounts:
-        orcl[0] = address(0x645F3BA6ed86D6f0965797563Fda6847932d78Df);
-        orcl[1] = address(0xa10ffb7e9842c7555575a25C53B6525A5a3f031d);
-        orcl[2] = address(0xd0d005224d30975a0A6eD382Ae2909c2c453D2a3);
-        orcl[3] = address(0x72C14464834831471eC11D1c9B9Fd2DE177Ab192);
-        orcl[4] = address(0x9E4f867264b636E8C72cA0C0Be0ECEfa313DFCB9);
-        orcl[5] = address(0x54Bf85C4072FE58d291A49f97d40bA1C3E177c16);
-        orcl[6] = address(0x3280F2601A6fC5cCa9b79E73501689053c9751Db);
-        orcl[7] = address(0xD1a5F6D8505317A25Cf63876BE7721C14ADFB569);
-        orcl[8] = address(0x2A3f1f975e2ed36bcc287D8A22956551B24D79B4);
-        orcl[9] = address(0x465C2617d41ba087EceC74830Ec08Ca4B36B8910);
-        orcl[10] = address(0x4b606049aAb6A1f969706b3E773B1c565Dab6964);
-        orcl[11] = address(0xAA360C3fb2B7E96F4BbD16Ad240A4C9b7a970495);
-        orcl[12] = address(0x7E66d64f550FB92589f2220682ffe9e59539d04F);
-        orcl[13] = address(0xE45Fbc125196280DC2B853695D913f94d727938c);
-        orcl[14] = address(0x9Ff0B627B21762361f112F46A5253C8866c33dE0);
+        orcl[0] = address(0xD62F2495678F4Ecd0db1730ebe07B6D21FF76397);
+        orcl[1] = address(0x22C5f295a5E5d16034A76d72eCA89Fe2a5433Da1);
+        orcl[2] = address(0x32DDb3c008FD5c2b10c8911893C8D7B5F3d313eD);
+        orcl[3] = address(0x9aE2A121803472837250ba9EC584fAaf2696E6d7);
+        orcl[4] = address(0x9b941A934309a272Ded4Fbf7fEDCdF2976d3729D);
+        orcl[5] = address(0x383DE40590D357dB29d6B3502c92536FBB08d716);
+        orcl[6] = address(0xbd2dC7A99c8A35955D36a30a2b763E9a23375484);
+        orcl[7] = address(0x20c7b8bb91068cEfF199b8Df184AD432Fcb2811B);
+        orcl[8] = address(0xd56e1469898c49cbE856FFE55988392030deA579);
+        orcl[9] = address(0x61244679E3bbC629e9bDb46bDd4f665da6B7c2C1);
+        orcl[10] = address(0x51d946B3392faF34823B5440A5b066Bb6fa41cAD);
+        orcl[11] = address(0xCc9C477562cD82fD7A14b48b98fd78c3FBf82F39);
+        orcl[12] = address(0x4495a0b4188949c98e8e1F14FeCB32529d5Ca192);
+        orcl[13] = address(0x6faED1C635Af2954caD8e08f12c8722c4bdF1F31);
+        orcl[14] = address(0xcfdFAC3A09a304F369B044d6b6cEE58428dF1563);
+        // ----------- prices:
+        price[0] = uint256(0x00000000000000000000000000000000000000000000000d9b5322251f0c0000);
+        price[1] = uint256(0x00000000000000000000000000000000000000000000000da933d8d8c6700000);
+        price[2] = uint256(0x00000000000000000000000000000000000000000000000db7148f8c6dd40000);
+        price[3] = uint256(0x00000000000000000000000000000000000000000000000dc4f5464015380000);
+        price[4] = uint256(0x00000000000000000000000000000000000000000000000dd2d5fcf3bc9c0000);
+        price[5] = uint256(0x00000000000000000000000000000000000000000000000de0b6b3a764000000);
+        price[6] = uint256(0x00000000000000000000000000000000000000000000000dee976a5b0b640000);
+        price[7] = uint256(0x00000000000000000000000000000000000000000000000dfc78210eb2c80000);
+        price[8] = uint256(0x00000000000000000000000000000000000000000000000e0a58d7c25a2c0000);
+        price[9] = uint256(0x00000000000000000000000000000000000000000000000e18398e7601900000);
+        price[10] = uint256(0x00000000000000000000000000000000000000000000000e261a4529a8f40000);
+        price[11] = uint256(0x00000000000000000000000000000000000000000000000e33fafbdd50580000);
+        price[12] = uint256(0x00000000000000000000000000000000000000000000000e41dbb290f7bc0000);
+        price[13] = uint256(0x00000000000000000000000000000000000000000000000e4fbc69449f200000);
+        price[14] = uint256(0x00000000000000000000000000000000000000000000000e5d9d1ff846840000);
+        // -------------- age, a.k.a. ts:
+        ts[0] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[1] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[2] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[3] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[4] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[5] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[6] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[7] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[8] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[9] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[10] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[11] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[12] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[13] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        ts[14] = uint256(0x00000000000000000000000000000000000000000000000000000000636a96dc);
+        // ---------------- r:
+        r[0] = bytes32(0x35d8f64caa0e32b877e8aeb143eac00cc372b578bef8e2d7e5c2c495f91edf05);
+        r[1] = bytes32(0x61dd79d54157ef0fc5dabea67b59b67a2dbd2024136700491bccaad7c8942315);
+        r[2] = bytes32(0x4290177bb69c6dc6257b3e9bebb439763533dadb13d2b1d2f99ef56e25f7e79f);
+        r[3] = bytes32(0xa86bfdeda25efdbb10528fa7612c7cf2159708c5ed0aa6e436c26f3837e1bf5b);
+        r[4] = bytes32(0x00627cc3ff9a5db1ace41c03f49dd4b35e090b27629627a49ec07a244cfa7e8d);
+        r[5] = bytes32(0x7094cf2f991d6abade7182b317075c0c594a7bf4ca5ec031e5b25eb567b4419b);
+        r[6] = bytes32(0x6713f7367c5264624582209941cf9de2b2e11dbd0581baefc7883c116259d8b1);
+        r[7] = bytes32(0x2490aa0a79c578570ab7306d2c3c81d74aa33c008394395c58accb1f3a8681c2);
+        r[8] = bytes32(0x60e8e1442ab1576d3b4d6f3ff254010e01bb659c39841741d2d1e2b25b7a79d2);
+        r[9] = bytes32(0x8d9b17bc997674e45d57834a79b5f3f8154c74b85bad23260411c32b899a9826);
+        r[10] = bytes32(0x0af236ad575937cf5d8e5ce9215d66361721d18e5e9e84dec1f258a359e26aec);
+        r[11] = bytes32(0xd3797829d7510f31c4ad7db5d55f1a1a9660277c16d076b2f0b78553c9a9d315);
+        r[12] = bytes32(0xe7a78c87859fa1463c801d7386f508f52be2e25b438234286d06094b621ef73f);
+        r[13] = bytes32(0xbac53afc5b42994aaae80b5330fdf303635c832cbd7c20ba562b02157f3579d6);
+        r[14] = bytes32(0x278fd8ac65e64234fb5c71a8282eb7b880ebffcf713ad861c54e6826b2aadc2a);
+        // ---------------- s:
+        s[0] = bytes32(0x1e70eda8837472027f3b32565ceb8788f34ef90204d41037991aefb04a98fed2);
+        s[1] = bytes32(0x1bc7bc92f764f1afd24b2cd3028ce4b87a40d23f9cb6e8159ed76ddb87c41228);
+        s[2] = bytes32(0x2024c87bb867a4ac8f73d67eb0b43dae5d463ee2b180e5cc1cb2def7c1c5e396);
+        s[3] = bytes32(0x0790d6023236deeb8f9e27f5624bb3bbe23b68d85886a59d0f86b718985d4343);
+        s[4] = bytes32(0x31fee84b7ef4176a50f46076af0ddb9d096467bd3e29c7a0a26905b896006b7d);
+        s[5] = bytes32(0x06078ac05248dfb7a6263cbe7a6ca6a04546df93e67be77533606fee82cfe829);
+        s[6] = bytes32(0x7dcd976bc9d89380b6d6eced67972649390ec2b6324d8ed0e8bc715cd07283d4);
+        s[7] = bytes32(0x0355c13dd52ccdc86a05efc4b7cc122ec78a6a785450166509f8e436a2e05db8);
+        s[8] = bytes32(0x7a397ca32b3e440a85f7cc888c5d4916492abcf562124d584a19ecae25a30fed);
+        s[9] = bytes32(0x788ef8eb29d57c8b1bef76313b0b7074e3534b824450df359f57c8b8bf7ec9fc);
+        s[10] = bytes32(0x6f11acc6d2691cbab5e25c8f467e6dc731ab14a5f9a5f1d4d925ea961bb940a8);
+        s[11] = bytes32(0x5d00a36c35ec82ba5b43d5ce960da016575a440fa4b140f0da03794c1f74580c);
+        s[12] = bytes32(0x084bf94357729448a92c1c4e44fffa6269c780896565b529dde9f4e9d3cea7e4);
+        s[13] = bytes32(0x5080d8cac0c096860e570bfa12fb38cf75b6eeb8b3a84dc05a424cae099f6201);
+        s[14] = bytes32(0x7221e1685e3c594e8172c6fb38f397414b59b48a25051763a6bec9c1bca6c387);
+        // ---------------- v:
+        v[0] = uint8(0x1c);
+        v[1] = uint8(0x1c);
+        v[2] = uint8(0x1b);
+        v[3] = uint8(0x1c);
+        v[4] = uint8(0x1b);
+        v[5] = uint8(0x1c);
+        v[6] = uint8(0x1c);
+        v[7] = uint8(0x1b);
+        v[8] = uint8(0x1c);
+        v[9] = uint8(0x1b);
+        v[10] = uint8(0x1b);
+        v[11] = uint8(0x1b);
+        v[12] = uint8(0x1b);
+        v[13] = uint8(0x1c);
+        v[14] = uint8(0x1c);
+
+        mosm.setBar(15);
+        mosm.lift(orcl);
+
+        return (orcl, price, ts, r, s, v);
+    }
+
+    function medianInit2() public returns
+        (address[] memory, uint256[] memory, uint256[] memory, bytes32[] memory, bytes32[] memory, uint8[] memory) {
+
+        address[] memory orcl = new address[](15);
+        uint256[] memory price = new uint256[](15);
+        uint256[] memory ts = new uint256[](15);
+        bytes32[] memory r = new bytes32[](15);
+        bytes32[] memory s = new bytes32[](15);
+        uint8[] memory v = new uint8[](15);
+
+        // ----------- accounts:
+        orcl[0] = address(0xD62F2495678F4Ecd0db1730ebe07B6D21FF76397);
+        orcl[1] = address(0x22C5f295a5E5d16034A76d72eCA89Fe2a5433Da1);
+        orcl[2] = address(0x32DDb3c008FD5c2b10c8911893C8D7B5F3d313eD);
+        orcl[3] = address(0x9aE2A121803472837250ba9EC584fAaf2696E6d7);
+        orcl[4] = address(0x9b941A934309a272Ded4Fbf7fEDCdF2976d3729D);
+        orcl[5] = address(0x383DE40590D357dB29d6B3502c92536FBB08d716);
+        orcl[6] = address(0xbd2dC7A99c8A35955D36a30a2b763E9a23375484);
+        orcl[7] = address(0x20c7b8bb91068cEfF199b8Df184AD432Fcb2811B);
+        orcl[8] = address(0xd56e1469898c49cbE856FFE55988392030deA579);
+        orcl[9] = address(0x61244679E3bbC629e9bDb46bDd4f665da6B7c2C1);
+        orcl[10] = address(0x51d946B3392faF34823B5440A5b066Bb6fa41cAD);
+        orcl[11] = address(0xCc9C477562cD82fD7A14b48b98fd78c3FBf82F39);
+        orcl[12] = address(0x4495a0b4188949c98e8e1F14FeCB32529d5Ca192);
+        orcl[13] = address(0x6faED1C635Af2954caD8e08f12c8722c4bdF1F31);
+        orcl[14] = address(0xcfdFAC3A09a304F369B044d6b6cEE58428dF1563);
         // ----------- prices:
         price[0] = uint256(0x00000000000000000000000000000000000000000000000579a814e10a740000);
         price[1] = uint256(0x0000000000000000000000000000000000000000000000058788cb94b1d80000);
@@ -81,181 +205,68 @@ contract MosmTest is DSTest {
         price[13] = uint256(0x0000000000000000000000000000000000000000000000062e115c008a880000);
         price[14] = uint256(0x0000000000000000000000000000000000000000000000063bf212b431ec0000);
         // -------------- age, a.k.a. ts:
-        ts[0] = uint32(0x62fbbbfe);
-        ts[1] = uint32(0x62fbbbfe);
-        ts[2] = uint32(0x62fbbbfe);
-        ts[3] = uint32(0x62fbbbfe);
-        ts[4] = uint32(0x62fbbbfe);
-        ts[5] = uint32(0x62fbbbfe);
-        ts[6] = uint32(0x62fbbbfe);
-        ts[7] = uint32(0x62fbbbfe);
-        ts[8] = uint32(0x62fbbbfe);
-        ts[9] = uint32(0x62fbbbfe);
-        ts[10] = uint32(0x62fbbbfe);
-        ts[11] = uint32(0x62fbbbfe);
-        ts[12] = uint32(0x62fbbbfe);
-        ts[13] = uint32(0x62fbbbfe);
-        ts[14] = uint32(0x62fbbbfe);
+        ts[0] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[1] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[2] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[3] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[4] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[5] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[6] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[7] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[8] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[9] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[10] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[11] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[12] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[13] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
+        ts[14] = uint256(0x00000000000000000000000000000000000000000000000000000000636a9841);
         // ---------------- r:
-        r[0] = bytes32(0xc90aa359dc7647268bc9128dc36727de6f7b110154890278b03fa35ed98318df);
-        r[1] = bytes32(0x318dc4b4d44584a31bf7c53cce25c80de097ecef0616136239e858dad0d65591);
-        r[2] = bytes32(0xbf918136b7d0b0bd3495ce38e2161e53f9d1d4a56717cf10bc0dece2c45cea77);
-        r[3] = bytes32(0x3a52abbaa60ba806bfcf5748083cc991790722821b3843d01901f359eebb33c1);
-        r[4] = bytes32(0x3e625b49e202038d278d96110eaa80cc6ba5665ed912949122ca7c43e047c92d);
-        r[5] = bytes32(0x29549ecfc63e56db02d728804fd878bff9a331775c8a565a7f1bdd244a128917);
-        r[6] = bytes32(0x94b553059947eb931746b0dd5c3a4c1bba052fabedb97ebdb6c5920634442a79);
-        r[7] = bytes32(0x4c6d1e884a3b9c89bd36973144c6910371a023ab4c4780e021887933012097cd);
-        r[8] = bytes32(0x54ee0173faaea34c764a679f0e0e736097a8bc62e0e125859731559be7044890);
-        r[9] = bytes32(0x3cc5d11e0f20454e02955dbaa700665a95db6415eb51e38fec352f9bb7f5b61b);
-        r[10] = bytes32(0x703b061ff53a13bbb6bae5ec6dbde3031d02e2fd4c27415c44bdab27b46d2e3f);
-        r[11] = bytes32(0x96b7f2acafe6fec5481ddc77fac735ee7537f7fc4e615f650b9170bb4ae3506c);
-        r[12] = bytes32(0x4db47b85c4f9f2d252ac84cf184b5492406d0569a214d8da767f8f2c16f7e38c);
-        r[13] = bytes32(0x26703e23859e510f7745d1c892f26367440abbc1d29fcca2b88576c5fcf45efa);
-        r[14] = bytes32(0x52328d363a990e2c14bb1a1630d66c82fe73a7c4376b621365bc8f92c057b172);
+        r[0] = bytes32(0x2f0752d9139a506189898fb78d66b42ba1d7702af434eec660fe758f7c2d44fe);
+        r[1] = bytes32(0x63ddbb97f1700fc1b5e4fb48d0257e3b5e3cb0d64c473319307f84cd291577e3);
+        r[2] = bytes32(0x78b7abae63b92e177561538cd2eced01a982d5623a74a096d27d5a88dfef6188);
+        r[3] = bytes32(0xa8a4715642f98548fecbb8748c2f00dde243b634daad7f19695c6f7dd0ab7a6d);
+        r[4] = bytes32(0x3bbe0e1a85f7a4de9379779761c9ff886ad4dd07b8e7e129b6f2afde3b3e9649);
+        r[5] = bytes32(0x575c7b7aa1cf8ee648e0297a747e9eb257747d828598ba2e10baed3e91f18c93);
+        r[6] = bytes32(0x2ea806822997fddccc8be5f632a4c92ce14dc40d8087a65e1a176c0412a227b7);
+        r[7] = bytes32(0x6bc08172e8b5ffb9707c19bc30ff6c99e26e0158dcb80959b48a576ef5e08e51);
+        r[8] = bytes32(0x10e6da16e8cea4603b2cb346a8e108c694430f6687538eb72ea7078732b35724);
+        r[9] = bytes32(0x9f2f2f8d0c935fe9ec619c3b4149d2344d40a1c8369e65a90870e9addd34a85f);
+        r[10] = bytes32(0xfe8db536234d1d09311af5496ab4e8e351608fb28294ff8ed36dc04e7862a234);
+        r[11] = bytes32(0xd5e55d8be3e271d0c4ee850174050e2c362f73e17e194fe3a1a7244b6b901007);
+        r[12] = bytes32(0xcc59240697e154f0298ba1a88fd7135c877c4e3bd839fa2c85f5ead778125ca4);
+        r[13] = bytes32(0xa9a07954f91b470de8739ede8386688be788a1581457011f5b141b0b1efd50cf);
+        r[14] = bytes32(0x35912a18b88696397536141da5c8ef4a0e2a327c5cef013288172930a86846bb);
         // ---------------- s:
-        s[0] = bytes32(0x633bf26dff94fbd7c09ac5c570bddd1a49e6a99739ce40207dfefd758d00cd06);
-        s[1] = bytes32(0x73dc937f2b7a95b1233f0a4b549027240277803dcbb2d4e8c6640a2611305911);
-        s[2] = bytes32(0x6f923abba40adee7915550d106764f3da71ad2b34085423afc462166981b785a);
-        s[3] = bytes32(0x40e072edf603dbc7c71dba9611bc6099423250901d353ecb18cace222262e6e1);
-        s[4] = bytes32(0x4b8c1a2ffd30c238838a1fc2377f94fe93020cd4eb0e966afb1a13a547e6b76e);
-        s[5] = bytes32(0x63a3197414c6b2ae4ec62b98707b52aa50162050e618bd2b93563b60655c3bdd);
-        s[6] = bytes32(0x6447a7ce3f97f90775ffe178aa1a9fbabfdee48b49098f589a17e65f29a52518);
-        s[7] = bytes32(0x3fead419647b6d6f4ce37ffa57fbbf6a381a846b969d3ac2cb9e196d6fdff13c);
-        s[8] = bytes32(0x3bc48c0638bcfba9f1834de26f695ac3504b4d10aa376637bae542a65f3a8823);
-        s[9] = bytes32(0x419217e68f47a628f9a2346e16b040534553dda8b67d735fcaf0409a0d677005);
-        s[10] = bytes32(0x52673c9b6e33443d37c15ae397dc9b09fd06fbeb3173f589a70f05d7c82a112b);
-        s[11] = bytes32(0x1928e2bee6ce618b90ba15019b9f22524fc2cd6a18482f80a723bd03b487e478);
-        s[12] = bytes32(0x3408ce0e133325145a2dcd74bc31badb6400dbf285e68803b22385ee6cda2bca);
-        s[13] = bytes32(0x6e6cbf00f78b4316111ce37fee4f5b84190f30de44e79ed582cb6fe6be9c08de);
-        s[14] = bytes32(0x18ce98478ee82aa091e09a2a8a0c6ae9b6315e12e7bfd679606fc80a0246bbbb);
+        s[0] = bytes32(0x23e7a51a54a0af41b519f8f29dd2392ce9acdeedf8c770c0f65f37df9435fe08);
+        s[1] = bytes32(0x435fc6e5bfa655a644d9470835e4a87d27216f3da70feefbc0ffd158313765f1);
+        s[2] = bytes32(0x2a2a66c45b5054224e87379b9bc91dcb68daccbde96ca73cf7aecb8ef42d3151);
+        s[3] = bytes32(0x3426d992396741b8289a2a950e91598892074208b0523bf08fac64901a8a2764);
+        s[4] = bytes32(0x046316e4a2b2452195a5c73ce4cc0ca51ba8f444756e3fe2d1e93d4741131fdc);
+        s[5] = bytes32(0x4ae952658ae6b3d3966b6e208e402b1ea09bb1812f6ca11892e78bf65e4a126f);
+        s[6] = bytes32(0x4a3d85faf2c24914bb873e1faca7fd37107d7ac4e634ef6f9a685214df4f54aa);
+        s[7] = bytes32(0x29f9028546a6a904f37f89094fd007c289718b40a66276773b7865c8b7d36003);
+        s[8] = bytes32(0x775257fa79d2034e8fc601b9e0834dff6f842450bc9496f59c2bd5d7d0fff9b6);
+        s[9] = bytes32(0x42438e1d3698fd7176c3a3f275e9774e302772bbf46d42390e9d37c288743aec);
+        s[10] = bytes32(0x7a224af42d043885506166c08b98148e9d39ecbe9bad4d67325e5028de07fe1b);
+        s[11] = bytes32(0x2d237ccdcc7a3a8cd3f5224ed132ef94d8448f452f677eda9a67a46a904e9cbd);
+        s[12] = bytes32(0x3e2c8eebab48a3b6880fc9cf67ecce6a7615885818e97b1f44a95d8261396c47);
+        s[13] = bytes32(0x596a4c9af5fabc756f0b9fe6b123c33c032ff11a6a1d53a9bc8f751e4eb68f66);
+        s[14] = bytes32(0x427ae701125ccf0c99d087cdcd111089591a7f36ca1c6633cae453db7efc6d0d);
         // ---------------- v:
-        v[0] = uint8(0x1c);
-        v[1] = uint8(0x1c);
+        v[0] = uint8(0x1b);
+        v[1] = uint8(0x1b);
         v[2] = uint8(0x1c);
-        v[3] = uint8(0x1c);
-        v[4] = uint8(0x1c);
+        v[3] = uint8(0x1b);
+        v[4] = uint8(0x1b);
         v[5] = uint8(0x1b);
         v[6] = uint8(0x1c);
         v[7] = uint8(0x1b);
-        v[8] = uint8(0x1b);
-        v[9] = uint8(0x1c);
-        v[10] = uint8(0x1c);
+        v[8] = uint8(0x1c);
+        v[9] = uint8(0x1b);
+        v[10] = uint8(0x1b);
         v[11] = uint8(0x1c);
         v[12] = uint8(0x1c);
-        v[13] = uint8(0x1b);
-        v[14] = uint8(0x1b);
-
-        mosm.setBar(15);
-        mosm.lift(orcl);
-
-        return (orcl, price, ts, r, s, v);
-    }
-
-    function medianInit2() public returns
-        (address[] memory, uint256[] memory, uint32[] memory, bytes32[] memory, bytes32[] memory, uint8[] memory) {
-
-        address[] memory orcl = new address[](15);
-        uint256[] memory price = new uint256[](15);
-        uint32[] memory ts = new uint32[](15);
-        bytes32[] memory r = new bytes32[](15);
-        bytes32[] memory s = new bytes32[](15);
-        uint8[] memory v = new uint8[](15);
-
-        // ----------- accounts:
-        orcl[0] = address(0x645F3BA6ed86D6f0965797563Fda6847932d78Df);
-        orcl[1] = address(0xa10ffb7e9842c7555575a25C53B6525A5a3f031d);
-        orcl[2] = address(0xd0d005224d30975a0A6eD382Ae2909c2c453D2a3);
-        orcl[3] = address(0x72C14464834831471eC11D1c9B9Fd2DE177Ab192);
-        orcl[4] = address(0x9E4f867264b636E8C72cA0C0Be0ECEfa313DFCB9);
-        orcl[5] = address(0x54Bf85C4072FE58d291A49f97d40bA1C3E177c16);
-        orcl[6] = address(0x3280F2601A6fC5cCa9b79E73501689053c9751Db);
-        orcl[7] = address(0xD1a5F6D8505317A25Cf63876BE7721C14ADFB569);
-        orcl[8] = address(0x2A3f1f975e2ed36bcc287D8A22956551B24D79B4);
-        orcl[9] = address(0x465C2617d41ba087EceC74830Ec08Ca4B36B8910);
-        orcl[10] = address(0x4b606049aAb6A1f969706b3E773B1c565Dab6964);
-        orcl[11] = address(0xAA360C3fb2B7E96F4BbD16Ad240A4C9b7a970495);
-        orcl[12] = address(0x7E66d64f550FB92589f2220682ffe9e59539d04F);
-        orcl[13] = address(0xE45Fbc125196280DC2B853695D913f94d727938c);
-        orcl[14] = address(0x9Ff0B627B21762361f112F46A5253C8866c33dE0);
-        // ----------- prices:
-        price[0] = uint256(0x0000000000000000000000000000000000000000000000058788cb94b1d80000);
-        price[1] = uint256(0x00000000000000000000000000000000000000000000000595698248593c0000);
-        price[2] = uint256(0x000000000000000000000000000000000000000000000005a34a38fc00a00000);
-        price[3] = uint256(0x000000000000000000000000000000000000000000000005b12aefafa8040000);
-        price[4] = uint256(0x000000000000000000000000000000000000000000000005bf0ba6634f680000);
-        price[5] = uint256(0x000000000000000000000000000000000000000000000005ccec5d16f6cc0000);
-        price[6] = uint256(0x000000000000000000000000000000000000000000000005dacd13ca9e300000);
-        price[7] = uint256(0x000000000000000000000000000000000000000000000005e8adca7e45940000);
-        price[8] = uint256(0x000000000000000000000000000000000000000000000005f68e8131ecf80000);
-        price[9] = uint256(0x000000000000000000000000000000000000000000000006046f37e5945c0000);
-        price[10] = uint256(0x000000000000000000000000000000000000000000000006124fee993bc00000);
-        price[11] = uint256(0x0000000000000000000000000000000000000000000000062030a54ce3240000);
-        price[12] = uint256(0x0000000000000000000000000000000000000000000000062e115c008a880000);
-        price[13] = uint256(0x0000000000000000000000000000000000000000000000063bf212b431ec0000);
-        price[14] = uint256(0x00000000000000000000000000000000000000000000000649d2c967d9500000);
-        // -------------- age, a.k.a. ts:
-        ts[0] = uint32(0x62fbbc55);
-        ts[1] = uint32(0x62fbbc55);
-        ts[2] = uint32(0x62fbbc55);
-        ts[3] = uint32(0x62fbbc55);
-        ts[4] = uint32(0x62fbbc55);
-        ts[5] = uint32(0x62fbbc55);
-        ts[6] = uint32(0x62fbbc55);
-        ts[7] = uint32(0x62fbbc55);
-        ts[8] = uint32(0x62fbbc55);
-        ts[9] = uint32(0x62fbbc55);
-        ts[10] = uint32(0x62fbbc55);
-        ts[11] = uint32(0x62fbbc55);
-        ts[12] = uint32(0x62fbbc55);
-        ts[13] = uint32(0x62fbbc55);
-        ts[14] = uint32(0x62fbbc55);
-        // ---------------- r:
-        r[0] = bytes32(0x6d87433fe06b6b3db416ec01ae3d0c1d36eb58d1f4f453a7148dcfd7b172eb41);
-        r[1] = bytes32(0x108bfa8f53e0e4e5aa5325a41e550816d63378bb4735c49dbcc6c8d4d8721b7e);
-        r[2] = bytes32(0x9a8b4f07a486b3a51c750cc1438949d90b2fcf25e4e0dbb2ba817c0360ace86c);
-        r[3] = bytes32(0xd40d09ba4bba91ebab4e109873149428e63a5b8736f4b1002c8d158edee5dadd);
-        r[4] = bytes32(0x9d1d4a7e5fbd13e7b9bb219c810a896f285ba01571a6a215fbb99ccbe27f0ff1);
-        r[5] = bytes32(0xa99a15de24d9783f350999541513107b725499c4b616ec6e37e3e2a9823b3c49);
-        r[6] = bytes32(0x8b78711fea5be145f639c6e7fbf5667c8ad03d83a8c7e439078000ab4969eb3b);
-        r[7] = bytes32(0x92ac15cab5025990b429ad367407fc31c3702fb06b09d552e1306a8eb8f3096d);
-        r[8] = bytes32(0x6e98770bebf868dc52cc29fe37c0fa432e5666a3a991081f23d31371cfbe911d);
-        r[9] = bytes32(0x73e760328d38743427694abfb4b8e7885d9d3a9fad4977c5c0120cdcc587f86b);
-        r[10] = bytes32(0x0dae5a8707b5a9428c7a514798ceee7393f0e16ccb16d1af530a48557debf7ec);
-        r[11] = bytes32(0x0f850fefe892f91f2da825453a80990b3c8eaa3b06fb2f4bfef1f0dbf04c1687);
-        r[12] = bytes32(0x0a1df69d7e3066e08589035e5aba60df4587efae2d60c4aeef465f74d34e6f63);
-        r[13] = bytes32(0x9c0886b7b08f36dc8a06f6c8ecc5536b4ae0067d95acf3160680c6240b1e1967);
-        r[14] = bytes32(0xad1236fee85f115c76d6949a62ecae35032ee18d8a0a5cd3e99ae9d22e8b2a27);
-        // ---------------- s:
-        s[0] = bytes32(0x066a5d90c56b25f8ca659b9f189948ec2fb7944bd7a80158561e4d2a82760639);
-        s[1] = bytes32(0x5e48796f0983596fa943d14758497b36b6253978af45b9e8e9bb6d351b33aa0f);
-        s[2] = bytes32(0x156e388b07854a54c6a9f13013261fe5f1cbf9c0369ff067634a603c2fd00c39);
-        s[3] = bytes32(0x4f4e0b7bc156713264f36aa3c15c12594f672a7097361aff19590f6c65091cfc);
-        s[4] = bytes32(0x7ce7faad1ec8ecc9c99eceef3864d43fcc24a01dbe1527c77b1ea26d60f33a94);
-        s[5] = bytes32(0x73dadac136bea2af1983a7a443499cf28703c78eb064b423486861eeb59de781);
-        s[6] = bytes32(0x032917bacca2129cebfa98d732df76c8ca3c5a0ff02ef04fb51e2d2aad0a45fb);
-        s[7] = bytes32(0x21875b6f58d5a694daec3684ade864c5f48ba14dbb65a3009c80273465427e9b);
-        s[8] = bytes32(0x07f4ccd97bb2651b0a8e034b14b0cd9242d5cb17f1f4915eb59b8ff7daf49c67);
-        s[9] = bytes32(0x0750b5a77a875d5293ca86a6256425cf096e3994930b2ff6fc09e41ff761bd4b);
-        s[10] = bytes32(0x019ac685aff0ad95b8b6db62d9cac0d1246905bbff60c581e0e22e879e889ee1);
-        s[11] = bytes32(0x676ed3720ca9620f5425fb12efe3caf2d05a25e4e2763f9528896f57114ab515);
-        s[12] = bytes32(0x669dbf5235b4c5a61caf4e959f9d1939dc75ead3ba70a655bce503280a7fd811);
-        s[13] = bytes32(0x6379c0fcd715b9f8d7d56cdd0a405a92a0de5b3c6a29699355a5cb744fdac031);
-        s[14] = bytes32(0x6375d1a689a5347604c0fcead48a3ceefcebc1beb3c8c911c8e21fc76047a152);
-        // ---------------- v:
-        v[0] = uint8(0x1c);
-        v[1] = uint8(0x1c);
-        v[2] = uint8(0x1c);
-        v[3] = uint8(0x1c);
-        v[4] = uint8(0x1c);
-        v[5] = uint8(0x1c);
-        v[6] = uint8(0x1b);
-        v[7] = uint8(0x1c);
-        v[8] = uint8(0x1b);
-        v[9] = uint8(0x1c);
-        v[10] = uint8(0x1b);
-        v[11] = uint8(0x1b);
-        v[12] = uint8(0x1c);
-        v[13] = uint8(0x1b);
+        v[13] = uint8(0x1c);
         v[14] = uint8(0x1b);
 
         mosm.setBar(15);
@@ -286,7 +297,7 @@ contract MosmTest is DSTest {
 
     function testMedian() public {
         (, uint256[] memory price,
-         uint32[] memory ts,
+         uint256[] memory ts,
          bytes32[] memory r,
          bytes32[] memory s,
          uint8[] memory v) = medianInit();
@@ -328,7 +339,7 @@ contract MosmTest is DSTest {
 
     function testFailMedianPoke() public {
         (, uint256[] memory price,
-         uint32[] memory ts,
+         uint256[] memory ts,
          bytes32[] memory r,
          bytes32[] memory s,
          uint8[] memory v) = medianInit();
@@ -350,7 +361,7 @@ contract MosmTest is DSTest {
 
     function testOsmVoidAndPoke() public {
         (, uint256[] memory price,
-         uint32[] memory ts,
+         uint256[] memory ts,
          bytes32[] memory r,
          bytes32[] memory s,
          uint8[] memory v) = medianInit();
@@ -388,7 +399,7 @@ contract MosmTest is DSTest {
 
     function testFailOsmPoke() public {
         (, uint256[] memory price,
-         uint32[] memory ts,
+         uint256[] memory ts,
          bytes32[] memory r,
          bytes32[] memory s,
          uint8[] memory v) = medianInit();
@@ -405,7 +416,7 @@ contract MosmTest is DSTest {
 
     function testOsmWhitelistPeep() public {
         (, uint256[] memory price,
-         uint32[] memory ts,
+         uint256[] memory ts,
          bytes32[] memory r,
          bytes32[] memory s,
          uint8[] memory v) = medianInit();
@@ -429,7 +440,7 @@ contract MosmTest is DSTest {
 
     function testOsmWhitelistPeek() public {
         (, uint256[] memory price,
-         uint32[] memory ts,
+         uint256[] memory ts,
          bytes32[] memory r,
          bytes32[] memory s,
          uint8[] memory v) = medianInit();
@@ -465,7 +476,7 @@ contract MosmTest is DSTest {
     function testOsmInterval() public {
         (address[] memory orcl,
          uint256[] memory price,
-         uint32[] memory ts,
+         uint256[] memory ts,
          bytes32[] memory r,
          bytes32[] memory s,
          uint8[] memory v) = medianInit();
@@ -513,5 +524,4 @@ contract MosmTest is DSTest {
         assertTrue(!ok);
         assertTrue(mosm.noop(price[7]));
     }
-
 }

--- a/test_median.sh
+++ b/test_median.sh
@@ -52,7 +52,7 @@ function hash {
     wat=$(seth --to-bytes32 "$(seth --from-ascii "$1")")    
     wad=$(seth --to-wei "$2" eth)
     wad=$(seth --to-word "$wad")
-    zzz=$(seth --to-word "$3" | sed 's/0\{56\}//g')
+    zzz=$(seth --to-word "$3")
 
     hexcat=$(echo "$wad$zzz$wat" | sed 's/0x//g')
     seth keccak 0x"$hexcat"
@@ -115,7 +115,7 @@ for acc in "${accounts[@]}"; do
     
     price=$(seth --to-wei "$price" eth)
     prices+=("$(seth --to-word "$price")")
-    tss+=("$(seth --to-word "$ts" | sed 's/0\{56\}//g')")
+    tss+=("$(seth --to-word $ts)")
     
     rs+=("0x$r")
     ss+=("0x$s")
@@ -144,7 +144,7 @@ if [ ! -z "$DUMP_PRICES_ONLY" ]; then
     echo "${allprices[@]}" | tr ',' '\n' | awk '{ print "price[" NR-1 "] = uint256(" $1 ");" }'
 
     echo '// -------------- age, a.k.a. ts:'
-    echo "${allts[@]}" | tr ',' '\n' | awk '{ print "ts[" NR-1 "] = uint32(" $1 ");" }'
+    echo "${allts[@]}" | tr ',' '\n' | awk '{ print "ts[" NR-1 "] = uint256(" $1 ");" }'
 
     echo '// ---------------- r:'
     echo "${allr[@]}" | tr ',' '\n' | awk '{ print "r[" NR-1 "] = bytes32(" $1 ");" }'
@@ -160,7 +160,7 @@ if [ ! -z "$DUMP_PRICES_ONLY" ]; then
 fi
 
 echo "Sending tx..."
-tx=$(set -x; seth send --async "$median" 'median_poke(uint256[] memory,uint256[] memory,uint8[] memory,bytes32[] memory,bytes32[] memory)' \
+tx=$(set -x; seth send --async "$median" 'poke(uint256[] memory,uint256[] memory,uint8[] memory,bytes32[] memory,bytes32[] memory)' \
 "[$allprices]" \
 "[$allts]" \
 "[$allv]" \


### PR DESCRIPTION
no calldata savings were gained switching `age` to `uint32` from `uint256`. switching back.