### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,12 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository and submodules
-      uses: actions/checkout@v2
+      uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       with:
         submodules: recursive
 
     - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@v1
+      uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d
       with:
         version: nightly
 


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/tests.yaml:8` `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5`
- `.github/workflows/tests.yaml:13` `foundry-rs/foundry-toolchain@v1` -> `foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d`